### PR TITLE
Menu items link full box

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -17,7 +17,7 @@ menus:
       name: Tags
       url: /tags
       weight: 40
-paginate: 10
+pagerSize: 10
 permalinks:
   blog: "/blog/:year/:month/:day/:title/"
 taxonomies:

--- a/layouts/partials/default_menu.html
+++ b/layouts/partials/default_menu.html
@@ -1,5 +1,7 @@
 {{ range .Site.Menus.main }}
-  <li class="font-bold border border-sky-400 px-3 py-2 hover:bg-sky-400 focus:text-sky-400 text-center">
-    <a href="{{ .URL }}">{{ .Name }}</a>
+  <li>
+    <a href="{{ .URL }}" class="font-bold border border-sky-400 px-3 py-2 hover:bg-sky-400 focus:text-sky-400 text-center">
+      {{ .Name }}
+    </a>
   </li>
 {{ end }}

--- a/layouts/partials/home_menu.html
+++ b/layouts/partials/home_menu.html
@@ -1,5 +1,7 @@
 {{ range .Site.Menus.main }}
-  <li class="font-bold border border-sky-400 p-2 hover:bg-sky-400 focus:text-sky-400 text-center">
-    <a href="{{ .URL }}">{{ .Name }}</a>
+  <li>
+    <a href="{{ .URL }}" class="font-bold border border-sky-400 p-2 hover:bg-sky-400 focus:text-sky-400 text-center">
+      {{ .Name }}
+    </a>
   </li>
 {{ end }}


### PR DESCRIPTION
# Menu item link full box

## Summary:

This pull request will help new developers use this theme by removing one error related with Hugo configuration key.
It also improves the user experience by making the menu box clickable and not only the text inside the box.

### What:

- Update the configuration key from `paginate` to `pageSize` in `hugo.yaml`.
- All the area of the menu item boxes will be affected by the link.

### Why:

- Site config key paginate was deprecated in Hugo v0.128.0 and subsequently removed. Use pagination.pagerSize instead.
- Previously only the text area was clickable, now the entire box is a link.

## Contributers
- @alvarocleite

